### PR TITLE
74-feature-snap-card-on-pointer-up

### DIFF
--- a/src/phaser/game/input/CardInteraction.ts
+++ b/src/phaser/game/input/CardInteraction.ts
@@ -58,8 +58,10 @@ export function setupCardInteraction(
       },
     );
 
-    cardController.view.on("pointerdown", () => {
+    cardController.view.on("pointerup", (pointer: Phaser.Input.Pointer) => {
       if (!isMovable()) return;
+      if (pointer.getDistance() > 1) return;
+
       snapCardToFoundationPile(deckController, cardController, moveHistory);
     });
   });


### PR DESCRIPTION
## Description
Card will only snap to foundation pile if the user interaction is specifically a click.

This means drags and putting the card back to it's original pile is valid as long as the user has moved the card significantly.

Fixes #74 

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

