### PR TITLE
[Bugfix] Streak wiped wo cause

### DIFF
--- a/src/app/api/game/completion/route.ts
+++ b/src/app/api/game/completion/route.ts
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth";
 import authOptions from "@/auth/config";
-import { updateStreakAndCompleteGame } from "@/lib/db/transactions";
+import { healStreak, upsertGame } from "@/lib/db/transactions";
 import { getCurrentUTCDateString } from "@/utils/Function";
 import { getDeal } from "@/lib/db/deals";
 
@@ -13,12 +13,14 @@ export async function POST(req: Request) {
   const deal = await getDeal(getCurrentUTCDateString());
   const { completionTimeMs, moveArray } = await req.json();
 
-  await updateStreakAndCompleteGame({
+  await upsertGame({
     userId: session.user.id,
     dealId: deal.id,
     elapsedTimeMs: completionTimeMs,
     moves: JSON.stringify(moveArray),
+    completed: true,
   });
+  await healStreak(session.user.id);
 
   return new Response(null, { status: 204 });
 }

--- a/src/app/api/game/progress/route.ts
+++ b/src/app/api/game/progress/route.ts
@@ -31,8 +31,12 @@ export async function POST(req: Request) {
   const deal = await getDeal(getCurrentUTCDateString());
   const { elapsedTimeMs, moveArray } = await req.json();
 
-  // upsertGame's `WHERE games.completed = false` guard ensures a periodic
-  // in-progress sync can never overwrite an already-completed game.
+  // A stale periodic sync must never clobber an already-completed game.
+  const game = await getGame({ userId: session.user.id, dealId: deal.id });
+  if (game?.completed) {
+    return new Response(null, { status: 204 });
+  }
+
   await upsertGame({
     userId: session.user.id,
     dealId: deal.id,

--- a/src/app/api/user/stats/route.ts
+++ b/src/app/api/user/stats/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import authOptions from "@/auth/config";
 import { getUserCompletionStats } from "@/lib/db/games";
 import { getStreak, resetStreak } from "@/lib/db/streaks";
+import { healStreak } from "@/lib/db/transactions";
 import { getDeal } from "@/lib/db/deals";
 import { getCurrentUTCDateString } from "@/utils/Function";
 
@@ -10,6 +11,10 @@ export async function GET() {
   if (!session?.user?.id) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Catches up `streaks` in case a prior completion crashed between
+  // upserting the game and healing the streak.
+  await healStreak(session.user.id);
 
   const { count, average } = await getUserCompletionStats(session.user.id);
   const streak = await getStreak(session.user.id);

--- a/src/lib/db/transactions.ts
+++ b/src/lib/db/transactions.ts
@@ -64,19 +64,32 @@ export async function updateStreakAndCompleteGame({
   elapsedTimeMs: number;
   moves: string;
 }) {
-  const [streak] = await sql<Streak[]>`
-    SELECT * FROM streaks
-    WHERE user_id = ${userId}
-  `;
-  if (!streak) {
-    throw new Error(`Missing streak for user ${userId}`);
-  }
-
-  const curr = streak.last_deal_id === dealId - 1 ? streak.curr + 1 : 1;
-  const max = Math.max(streak.max, curr);
-  const lastDealId = dealId;
-
   await sql.begin(async (tx) => {
+    // Lock the game row first: if it's already completed, this is a repeat
+    // sync (e.g. the client re-posting a completion it already recorded
+    // after a remount/refresh) and the streak must not be touched again,
+    // since last_deal_id has already advanced to today's deal.
+    const [existingGame] = await tx`
+      SELECT completed FROM games
+      WHERE user_id = ${userId} AND deal_id = ${dealId}
+      FOR UPDATE
+    `;
+    if (existingGame?.completed) {
+      return;
+    }
+
+    const [streak] = await tx<Streak[]>`
+      SELECT * FROM streaks
+      WHERE user_id = ${userId}
+      FOR UPDATE
+    `;
+    if (!streak) {
+      throw new Error(`Missing streak for user ${userId}`);
+    }
+
+    const curr = streak.last_deal_id === dealId - 1 ? streak.curr + 1 : 1;
+    const max = Math.max(streak.max, curr);
+
     await upsertGame(
       { userId, dealId, elapsedTimeMs, moves, completed: true },
       tx,
@@ -85,7 +98,7 @@ export async function updateStreakAndCompleteGame({
       UPDATE streaks
       SET curr = ${curr},
           max = ${max},
-          last_deal_id = ${lastDealId}
+          last_deal_id = ${dealId}
       WHERE user_id = ${userId}
     `;
   });

--- a/src/lib/db/transactions.ts
+++ b/src/lib/db/transactions.ts
@@ -40,52 +40,48 @@ export async function upsertGame(
   },
   tx: Sql = sql,
 ) {
-  // Once a game is marked completed, the server's state is authoritative:
-  // further upserts (e.g. late progress syncs from the client) are no-ops.
+  // Unconditional overwrite — caller is responsible for not clobbering an
+  // already-completed game (check first, in the same transaction).
   await tx`
     INSERT INTO games (user_id, deal_id, elapsed_time_ms, moves, completed)
     VALUES (${userId}, ${dealId}, ${elapsedTimeMs}, ${moves}::jsonb, ${completed})
     ON CONFLICT (user_id, deal_id) DO UPDATE
     SET elapsed_time_ms = EXCLUDED.elapsed_time_ms,
         moves = EXCLUDED.moves,
-        completed = games.completed OR EXCLUDED.completed
-    WHERE games.completed = false
+        completed = EXCLUDED.completed
   `;
 }
 
-export async function updateStreakAndCompleteGame({
-  userId,
-  dealId,
-  elapsedTimeMs,
-  moves,
-}: {
-  userId: string;
-  dealId: number;
-  elapsedTimeMs: number;
-  moves: string;
-}) {
-  const [streak] = await sql<Streak[]>`
-    SELECT * FROM streaks
-    WHERE user_id = ${userId}
-  `;
-  if (!streak) {
-    throw new Error(`Missing streak for user ${userId}`);
-  }
-
-  const curr = streak.last_deal_id === dealId - 1 ? streak.curr + 1 : 1;
-  const max = Math.max(streak.max, curr);
-  const lastDealId = dealId;
-
+// Idempotent: reconciles `streaks` against the latest completed deal in
+// `games` (the source of truth). Safe to call redundantly from anywhere
+// (after a completion, from a stats fetch, ...) — a no-op if already healed.
+export async function healStreak(userId: string) {
   await sql.begin(async (tx) => {
-    await upsertGame(
-      { userId, dealId, elapsedTimeMs, moves, completed: true },
-      tx,
-    );
+    const [streak] = await tx<Streak[]>`
+      SELECT * FROM streaks
+      WHERE user_id = ${userId}
+      FOR UPDATE
+    `;
+
+    const [latest] = await tx`
+      SELECT deal_id FROM games
+      WHERE user_id = ${userId} AND completed = true
+      ORDER BY deal_id DESC
+      LIMIT 1
+    `;
+    if (!latest || latest.deal_id === streak.last_deal_id) {
+      return;
+    }
+
+    const curr =
+      streak.last_deal_id === latest.deal_id - 1 ? streak.curr + 1 : 1;
+    const max = Math.max(streak.max, curr);
+
     await tx`
       UPDATE streaks
       SET curr = ${curr},
           max = ${max},
-          last_deal_id = ${lastDealId}
+          last_deal_id = ${latest.deal_id}
       WHERE user_id = ${userId}
     `;
   });

--- a/src/lib/db/transactions.ts
+++ b/src/lib/db/transactions.ts
@@ -64,32 +64,19 @@ export async function updateStreakAndCompleteGame({
   elapsedTimeMs: number;
   moves: string;
 }) {
+  const [streak] = await sql<Streak[]>`
+    SELECT * FROM streaks
+    WHERE user_id = ${userId}
+  `;
+  if (!streak) {
+    throw new Error(`Missing streak for user ${userId}`);
+  }
+
+  const curr = streak.last_deal_id === dealId - 1 ? streak.curr + 1 : 1;
+  const max = Math.max(streak.max, curr);
+  const lastDealId = dealId;
+
   await sql.begin(async (tx) => {
-    // Lock the game row first: if it's already completed, this is a repeat
-    // sync (e.g. the client re-posting a completion it already recorded
-    // after a remount/refresh) and the streak must not be touched again,
-    // since last_deal_id has already advanced to today's deal.
-    const [existingGame] = await tx`
-      SELECT completed FROM games
-      WHERE user_id = ${userId} AND deal_id = ${dealId}
-      FOR UPDATE
-    `;
-    if (existingGame?.completed) {
-      return;
-    }
-
-    const [streak] = await tx<Streak[]>`
-      SELECT * FROM streaks
-      WHERE user_id = ${userId}
-      FOR UPDATE
-    `;
-    if (!streak) {
-      throw new Error(`Missing streak for user ${userId}`);
-    }
-
-    const curr = streak.last_deal_id === dealId - 1 ? streak.curr + 1 : 1;
-    const max = Math.max(streak.max, curr);
-
     await upsertGame(
       { userId, dealId, elapsedTimeMs, moves, completed: true },
       tx,
@@ -98,7 +85,7 @@ export async function updateStreakAndCompleteGame({
       UPDATE streaks
       SET curr = ${curr},
           max = ${max},
-          last_deal_id = ${dealId}
+          last_deal_id = ${lastDealId}
       WHERE user_id = ${userId}
     `;
   });


### PR DESCRIPTION
## Description
Updating the streak was previously NOT an idempotent action. Updating the streak twice in a day (via repeat calls to 'updateStreakAndCompleteGame' would reset a user's streak to 1.

We've resolved by breaking that function into 'upsertGame' and 'healStreak', the latter of which can be called as many times as you'd like to recalculate the user's streak.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
